### PR TITLE
Ruby/remove gts from ogmeta

### DIFF
--- a/internal/api/util/opengraph.go
+++ b/internal/api/util/opengraph.go
@@ -67,7 +67,7 @@ func OGBase(instance *apimodel.InstanceV1) *OGMeta {
 	}
 
 	og := &OGMeta{
-		Title:       text.SanitizeToPlaintext(instance.Title) + " - GoToSocial",
+		Title:       text.SanitizeToPlaintext(instance.Title),
 		Type:        "website",
 		Locale:      locale,
 		URL:         instance.URI,

--- a/web/template/page.tmpl
+++ b/web/template/page.tmpl
@@ -37,7 +37,7 @@ image/webp
 {{- if .ogMeta -}}
 {{- demojify .ogMeta.Title | noescape -}}
 {{- else -}}
-{{- .instance.Title }} - GoToSocial
+{{- .instance.Title }}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Just removes "- GoTo Social" from OGMeta and the index page title.

`rosemade` only. Not for upstream