### PR TITLE
Update OpenGraph / RSS site names, titles, etc

### DIFF
--- a/internal/api/util/opengraph.go
+++ b/internal/api/util/opengraph.go
@@ -66,12 +66,14 @@ func OGBase(instance *apimodel.InstanceV1) *OGMeta {
 		locale = instance.Languages[0]
 	}
 
+	instanceName := text.SanitizeToPlaintext(instance.Title)
+
 	og := &OGMeta{
-		Title:       text.SanitizeToPlaintext(instance.Title),
+		Title:       instanceName,
 		Type:        "website",
 		Locale:      locale,
 		URL:         instance.URI,
-		SiteName:    instance.AccountDomain,
+		SiteName:    instanceName,
 		Description: ParseDescription(instance.ShortDescription),
 
 		Image:    "",
@@ -85,7 +87,9 @@ func OGBase(instance *apimodel.InstanceV1) *OGMeta {
 // struct specific to that account. It's suitable for serving
 // at account profile pages.
 func (og *OGMeta) WithAccount(account *apimodel.WebAccount) *OGMeta {
-	og.Title = AccountTitle(account, og.SiteName)
+	attribution := AccountTitle(account, og.SiteName)
+	og.Title = attribution
+	og.SiteName = attribution
 	og.Type = "profile"
 	og.URL = account.URL
 	if account.Note != "" {
@@ -106,17 +110,37 @@ func (og *OGMeta) WithAccount(account *apimodel.WebAccount) *OGMeta {
 // struct specific to that status. It's suitable for serving
 // at status pages.
 func (og *OGMeta) WithStatus(status *apimodel.WebStatus) *OGMeta {
-	og.Title = "Post by " + AccountTitle(status.Account, og.SiteName)
+	attribution := AccountTitle(status.Account, og.SiteName)
+	og.Title = attribution
+	og.SiteName = attribution
 	og.Type = "article"
 	if status.Language != nil {
 		og.Locale = *status.Language
 	}
 	og.URL = status.URL
+
+	statusText := status.Text
+
+	if statusText != "" {
+		// try to extract a markdown heading on the very first line
+		// and use it as the title
+		lines := strings.Split(status.Text, "\n")
+		if len(lines) > 0 {
+			firstLine := lines[0]
+			if strings.HasPrefix(firstLine, "# ") {
+				og.Title = text.SanitizeToPlaintext(firstLine[2:])
+
+				// remove the first line from the text
+				statusText = strings.Join(lines[1:], "\n")
+			}
+		}
+	}
+
 	switch {
 	case status.SpoilerText != "":
 		og.Description = ParseDescription("CW: " + status.SpoilerText)
-	case status.Text != "":
-		og.Description = ParseDescription(status.Text)
+	case statusText != "":
+		og.Description = ParseDescription(statusText)
 	default:
 		og.Description = og.Title
 	}
@@ -145,14 +169,12 @@ func (og *OGMeta) WithStatus(status *apimodel.WebStatus) *OGMeta {
 }
 
 // AccountTitle parses a page title from account and accountDomain
-func AccountTitle(account *apimodel.WebAccount, accountDomain string) string {
-	user := "@" + account.Acct + "@" + accountDomain
-
+func AccountTitle(account *apimodel.WebAccount, siteName string) string {
 	if len(account.DisplayName) == 0 {
-		return user
+		return account.Acct + " on " + siteName
 	}
 
-	return account.DisplayName + ", " + user
+	return account.DisplayName + " on " + siteName
 }
 
 // ParseDescription returns a string description which is

--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -1038,7 +1038,6 @@ func (a *accountDB) GetAccountWebStatuses(
 		Column("status.id").
 		Where("? = ?", bun.Ident("status.account_id"), account.ID).
 		// Don't show replies or boosts.
-		Where("? IS NULL", bun.Ident("status.in_reply_to_uri")).
 		Where("? IS NULL", bun.Ident("status.boost_of_id"))
 
 	// Select statuses for this account according

--- a/internal/processing/account/rss.go
+++ b/internal/processing/account/rss.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/gorilla/feeds"
-	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
@@ -82,7 +81,13 @@ func (p *Processor) GetRSSFeedForUsername(ctx context.Context, username string) 
 
 	return func() (string, gtserror.WithCode) {
 		// Assemble author namestring once only.
-		author := "@" + account.Username + "@" + config.GetAccountDomain()
+		//author := "@" + account.Username + "@" + config.GetAccountDomain()
+		var author string
+		if account.DisplayName != "" {
+			author = account.DisplayName
+		} else {
+			author = account.Username
+		}
 
 		// Derive image/thumbnail for this account (may be nil).
 		image, errWithCode := p.rssImageForAccount(ctx, account, author)
@@ -91,8 +96,8 @@ func (p *Processor) GetRSSFeedForUsername(ctx context.Context, username string) 
 		}
 
 		feed := &feeds.Feed{
-			Title:       "Posts from " + author,
-			Description: "Posts from " + author,
+			Title:       author,
+			Description: author,
 			Link:        &feeds.Link{Href: account.URL},
 			Image:       image,
 		}

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -49,7 +49,7 @@ const (
 	instancePollsMinExpiration               = 300     // seconds
 	instancePollsMaxExpiration               = 2629746 // seconds
 	instanceAccountsMaxFeaturedTags          = 10
-	instanceAccountsMaxProfileFields         = 6 // FIXME: https://github.com/superseriousbusiness/gotosocial/issues/1876
+	instanceAccountsMaxProfileFields         = 20 // FIXME: https://github.com/superseriousbusiness/gotosocial/issues/1876
 	instanceSourceURL                        = "https://github.com/superseriousbusiness/gotosocial"
 	instanceMastodonVersion                  = "3.5.3"
 )

--- a/internal/typeutils/internaltorss.go
+++ b/internal/typeutils/internaltorss.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/gorilla/feeds"
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
-	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/text"
@@ -42,11 +41,34 @@ func (c *Converter) StatusToRSSItem(ctx context.Context, s *gtsmodel.Status) (*f
 	// Title -- The title of the item.
 	// example: Venice Film Festival Tries to Quit Sinking
 	var title string
-	if s.ContentWarning != "" {
-		title = trimTo(s.ContentWarning, rssTitleMaxRunes)
-	} else {
-		title = trimTo(s.Text, rssTitleMaxRunes)
+
+	// search for markdown title in first line
+	statusText := s.Text
+
+	if statusText != "" {
+		// try to extract a markdown heading on the very first line
+		// and use it as the title
+		lines := strings.Split(statusText, "\n")
+		if len(lines) > 0 {
+			firstLine := lines[0]
+			if strings.HasPrefix(firstLine, "# ") {
+				title = text.SanitizeToPlaintext(firstLine[2:])
+
+				// remove the first line from the text
+				statusText = strings.Join(lines[1:], "\n")
+			}
+		}
 	}
+
+	if title == "" {
+		if s.ContentWarning != "" {
+			title = "CW: " + s.ContentWarning
+		} else {
+			title = statusText
+		}
+	}
+
+	title = trimTo(title, rssTitleMaxRunes)
 
 	// Link -- The URL of the item.
 	// example: http://nytimes.com/2004/12/07FEST.html
@@ -63,7 +85,11 @@ func (c *Converter) StatusToRSSItem(ctx context.Context, s *gtsmodel.Status) (*f
 		}
 		s.Account = a
 	}
-	authorName := "@" + s.Account.Username + "@" + config.GetAccountDomain()
+	authorName := s.Account.DisplayName
+	if authorName == "" {
+		authorName = s.Account.Username
+	}
+	// authorName := "@" + s.Account.Username + "@" + config.GetAccountDomain()
 	author := &feeds.Author{
 		Name: authorName,
 	}
@@ -76,25 +102,32 @@ func (c *Converter) StatusToRSSItem(ctx context.Context, s *gtsmodel.Status) (*f
 	// Description -- The item synopsis.
 	// example: Some of the most heated chatter at the Venice Film Festival this week was about the way that the arrival of the stars at the Palazzo del Cinema was being staged.
 	descriptionBuilder := strings.Builder{}
-	descriptionBuilder.WriteString(authorName + " ")
+	// descriptionBuilder.WriteString(authorName + " ")
 
-	attachmentCount := len(s.Attachments)
-	if len(s.AttachmentIDs) > attachmentCount {
-		attachmentCount = len(s.AttachmentIDs)
-	}
-	switch {
-	case attachmentCount > 1:
-		descriptionBuilder.WriteString(fmt.Sprintf("posted [%d] attachments", attachmentCount))
-	case attachmentCount == 1:
-		descriptionBuilder.WriteString("posted 1 attachment")
-	default:
-		descriptionBuilder.WriteString("made a new post")
-	}
+	// attachmentCount := len(s.Attachments)
+	// if len(s.AttachmentIDs) > attachmentCount {
+	// 	attachmentCount = len(s.AttachmentIDs)
+	// }
+	// switch {
+	// case attachmentCount > 1:
+	// 	descriptionBuilder.WriteString(fmt.Sprintf("posted [%d] attachments", attachmentCount))
+	// case attachmentCount == 1:
+	// 	descriptionBuilder.WriteString("posted 1 attachment")
+	// default:
+	// 	descriptionBuilder.WriteString("made a new post")
+	// }
 
-	if s.Text != "" {
-		descriptionBuilder.WriteString(": \"")
-		descriptionBuilder.WriteString(s.Text)
-		descriptionBuilder.WriteString("\"")
+	// if s.Text != "" {
+	// 	descriptionBuilder.WriteString(": \"")
+	// 	descriptionBuilder.WriteString(s.Text)
+	// 	descriptionBuilder.WriteString("\"")
+	// }
+
+	if s.ContentWarning != "" {
+		descriptionBuilder.WriteString("CW: ")
+		descriptionBuilder.WriteString(s.ContentWarning)
+	} else {
+		descriptionBuilder.WriteString(statusText)
 	}
 
 	description := trimTo(descriptionBuilder.String(), rssDescriptionMaxRunes)
@@ -151,7 +184,14 @@ func (c *Converter) StatusToRSSItem(ctx context.Context, s *gtsmodel.Status) (*f
 			apiEmojis = append(apiEmojis, apiEmoji)
 		}
 	}
-	content := text.EmojifyRSS(apiEmojis, s.Content)
+
+	var content string
+
+	if s.ContentWarning != "" {
+		content = text.EmojifyRSS(apiEmojis, s.ContentWarning)
+	} else {
+		content = text.EmojifyRSS(apiEmojis, s.Content)
+	}
 
 	return &feeds.Item{
 		Title:       title,

--- a/internal/validate/formvalidation.go
+++ b/internal/validate/formvalidation.go
@@ -42,7 +42,7 @@ const (
 	maximumUsernameLength         = 64
 	maximumEmojiCategoryLength    = 64
 	maximumProfileFieldLength     = 255
-	maximumProfileFields          = 6
+	maximumProfileFields          = 20
 	maximumListTitleLength        = 200
 	maximumFilterKeywordLength    = 40
 	maximumFilterTitleLength      = 200

--- a/web/source/settings/views/user/profile.tsx
+++ b/web/source/settings/views/user/profile.tsx
@@ -79,7 +79,7 @@ function UserProfileForm({ data: profile }: UserProfileFormProps) {
 	const instanceConfig = React.useMemo(() => {
 		return {
 			allowCustomCSS: instance?.configuration?.accounts?.allow_custom_css === true,
-			maxPinnedFields: instance?.configuration?.accounts?.max_profile_fields ?? 6
+			maxPinnedFields: instance?.configuration?.accounts?.max_profile_fields ?? 20
 		};
 	}, [instance]);
 	


### PR DESCRIPTION
Not for upstream, rosemade only

Lots of little changes and refinements to OpenGraph and RSS presentation.

* Change SiteName for all pages to be from domain name to instance name ("garden of roses" as opposed to "rosemade.art")
* Set index page title to also be instance name
* Just use display name wherever account name appears, instead of display name and/or @username@rosemade.art
* Pull status Title from first line if it is a Level 1 markdown header. - put the remaining lines into Text
* Use Title for ogMeta and RSS title.
* Use CW as ogMeta title alone if no Title but CW is present
* Always use CW as status text in RSS, if present
* Cohost like format for User specific site name and title-less statuses
  * User specific pages (profile, threads) use the Site Name "[Account Display Name] on [Instance Name], instead of "Posts by" or anything like that
  * Will use that user-specific Site Name if the post doesn't have a Title.
* RSS uses the same, but only [Account Display Name]. Removes "Posts by"
* RSS removes all the action history from Description and simply puts the status text (or CW if present)

Also:

* Allow replies to go onto main account page feed as well as RSS. Needs more future refinement as it is presented as a normal post without association or any visual indication to the parent post. Might want to consider presenting this like cohost did.

![With title and CW](https://github.com/user-attachments/assets/850eab0c-f5e3-44a5-8277-124388d99373)
<figcaption>With title and CW</figcaption>

![No title, no CW](https://github.com/user-attachments/assets/5b89a024-e74b-443e-a6a5-bd40d1af6962)
<figcaption>No title, no CW</figcaption>

